### PR TITLE
Add basic tooltips via title attribute consisting of desc for edges, abilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
                                 <div class="form-group">
                                     <select multiple class="form-control" size="27" ng-model="statBlock.edges">
                                         <option ng-repeat="edge in edges"
+                                                title="{{ edge.desc }}"
                                                 value="{{ edge }}" ng-bind="edge.name">
                                         </option>
                                     </select>
@@ -213,6 +214,7 @@
                                 <div class="form-group">
                                     <select multiple class="form-control" size="27" ng-model="statBlock.specialAbilities">
                                         <option ng-repeat="ability in specialAbilities"
+                                                title="{{ ability.desc }}"
                                                 value="{{ ability }}" ng-bind="ability.name">
                                         </option>
                                     </select>


### PR DESCRIPTION
This will add the ability to do a "mouse cursor hover" and get the description displayed as a floating tooltip. Implementation is simply adding in the html element attribute "title" into the NG template.

This feature is not well supported on mobile browsers yet. But there may be some javascript/css technique that could work similarly. There is also a Boopstrap component called tooltips. Deferring on mobile for some research and a future modification.
