### PR TITLE
Model property "attributes" renamed "skills" to better reflect original game documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,8 +169,8 @@
                         <div id="collapseSkills" class="panel-collapse collapse">
                             <div class="panel-body">
                                 <div class="form-group">
-                                    <die-picker ng-repeat="attribute in statBlock.attributes" stat="attribute.value"
-                                                statname="attribute.name"></die-picker>
+                                    <die-picker ng-repeat="skill in statBlock.skills" stat="skill.value"
+                                                statname="skill.name"></die-picker>
                                 </div>
                             </div>
                         </div>
@@ -372,9 +372,9 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                <tr ng-repeat="attr in statBlock.attributes | filter:itemHasValue()">
+                                <tr ng-repeat="skill in statBlock.skills | filter:itemHasValue()">
                                     <td>
-                                        {{ statBlock.getObjectFromJsonString(attr).name }}: d{{ statBlock.getObjectFromJsonString(attr).value }}
+                                        {{ statBlock.getObjectFromJsonString(skill).name }}: d{{ statBlock.getObjectFromJsonString(skill).value }}
                                     </td>
                                 </tr>
                                 </tbody>

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -9,7 +9,7 @@ app.controller('mainController', function($scope) {
         strength: { name: 'Strength', value: '6'},
         vigor: { name: 'Vigor', value: '6'},
 
-        attributes: [
+        skills: [
             {name: 'Arcane', value: ''},
             {name: 'Boating', value: ''},
             {name: 'Climbing', value: ''},
@@ -35,8 +35,8 @@ app.controller('mainController', function($scope) {
         },
 
         parry: function() {
-            var fightingAttributeIndex = 4;
-            return (this.attributes[fightingAttributeIndex].value / 2) + 2 +
+            var fightingSkillIndex = 4;
+            return (this.skills[fightingSkillIndex].value / 2) + 2 +
                     this.abilityAdditions(this.edges, 'parry');
         },
 
@@ -82,7 +82,7 @@ app.controller('mainController', function($scope) {
                      (this.strengthBonus) +
                      (((this.vigor.value / 2) - 1) * 3) +
                      (this.pace - 6) +
-                     this.costOfAttributes() +
+                     this.costOfSkills() +
                      this.costOf(this.edges) +
                      this.costOf(this.specialAbilities) +
                      this.costOf(this.miscAbilities) +
@@ -118,10 +118,10 @@ app.controller('mainController', function($scope) {
             return sum;
         },
 
-        costOfAttributes: function() {
+        costOfSkills: function() {
             var first = true;
             var sum = 0;
-            this.attributes.forEach(function(itemString) {
+            this.skills.forEach(function(itemString) {
               var item = angular.fromJson(itemString);
               if (item.value != "") {
                   if (first) {


### PR DESCRIPTION
According to my reading "Traits" are a superset of "Skills" (fighting, throwing, etc.) and more-or-less congenital/invariant Attributes (agility, strength, etc.). By this understanding, I believe the statBlock member "attributes" (and accordingly all references in the index.html views) should be renamed to "skills".

Passed regression test consisting of: creating wild card "Robin Hood" before change, and after. Same point val calced, and print modal dialogs appeared identical.
