### PR TITLE
Add Wild Card icon

### DIFF
--- a/css/showdownTroopBuilder.css
+++ b/css/showdownTroopBuilder.css
@@ -1,3 +1,11 @@
 #wc-glyphicon {
-	margin-left: 1em;
+	margin-left: 1.25em;
+	margin-top: .25em;
+}
+
+@media (min-width: 480px) {
+	#wc-glyphicon {
+		display: block;
+		margin-left: .75em;
+	}
 }

--- a/css/showdownTroopBuilder.css
+++ b/css/showdownTroopBuilder.css
@@ -1,0 +1,3 @@
+#wc-glyphicon {
+	margin-left: 1em;
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <title>Showdown Troop Builder</title>
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/bootstrap-theme.min.css" rel="stylesheet">
+    <link href="css/showdownTroopBuilder.css" rel="stylesheet">
 
     <!--<script src="https://code.jquery.com/jquery.js"></script>-->
     <script src="js/shared/jquery-1.11.1.min.js"></script>
@@ -82,6 +83,7 @@
                                     <div class="form-group">
                                         <label>Wild Card:</label>
                                         <input type="checkbox" value="false" ng-model="statBlock.wildCard" id="wc">
+                                        <span  ng-show="statBlock.wildCard" ng-class="'glyphicon glyphicon-' + this.wcGlyphiconSet[this.statBlock.wildCardIconIndex]" aria-hidden="true" ng-click="wildcardIconCycle()" id="wc-glyphicon"> </span>
                                     </div>
                                 </div>
                             </div>
@@ -315,6 +317,8 @@
             This game references the Savage Worlds game system, available from Pinnacle Entertainment Group at www.peginc.com.
             Savage Worlds and all associated logos and trademarks are copyrights of Pinnacle Entertainment Group. Used with permission.
             Pinnacle makes no representation or warranty as to the quality, viability, or suitability for purpose of this product.
+            
+            Built-in Bootstrap Glyphicons courtesy of <a href="http://glyphicons.com/">Glyphicons</a>.
         </div>
         <div class="col-md-1"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -333,7 +333,10 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h4>Name: {{ statBlock.name }} {{ statBlock.wildCard ? '(WC)' : '' }}</h4>
+                <h4>Name: {{ statBlock.name }} 
+                  <span  ng-show="statBlock.wildCard" ng-class="'glyphicon glyphicon-' + this.wcGlyphiconSet[this.statBlock.wildCardIconIndex]" aria-hidden="true" id="wc-glyphicon-print"> </span>
+                </h4>
+
             </div>
             <div class="modal-body">
 

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -3,6 +3,7 @@ app.controller('mainController', function($scope) {
     $scope.statBlock = {
         name: '',
         wildCard: false,
+        wildCardIconIndex: 0,
         agility: { name: 'Agility', value: '6'},
         smarts: { name: 'Smarts', value: '6'},
         spirit: { name: 'Spirit', value: '6'},
@@ -150,6 +151,12 @@ app.controller('mainController', function($scope) {
 
     };
 
+    $scope.wcGlyphiconSet = [
+      'asterisk','plus','cloud','heart','star','star-empty','th','remove','off','cog','flag','book','bookmark','tint','move','plus-sign','remove-sign','screenshot','remove-circle','leaf','fire','eye-open','plane','bell','certificate','wrench','fullscreen','heart-empty','link','unchecked','flash','record','send','tower'
+		/* Apparently not available in currently utilzed version of Boostrap:
+		 ,'conifer','cd','alert','king','queen','pawn','bishop','knight','apple','hourglass','grain','triangle-top' */
+    ];
+
     // Reference Data
     $scope.edges = EDGES;
     $scope.specialAbilities = SPECIAL_ABILITIES;
@@ -162,6 +169,12 @@ app.controller('mainController', function($scope) {
       return function( item ) {
         return item.value != '';
       };
+    };
+
+      
+    $scope.wildcardIconCycle = function() {
+      //Just cycle to the next icon. The icons are the "built-in" Bootstrap icons, selected for proper flavor.
+        this.statBlock.wildCardIconIndex = (this.statBlock.wildCardIconIndex + 1) % this.wcGlyphiconSet.length;
     };
 
 });


### PR DESCRIPTION
When Wild Card checkbox is checked, show a Wild Card icon. Uses the "built-in" GlyphIcons from bootstrap. Clicking on the icon itself cycles through a selection of alternatives that sort of have the right "flavor" for the game.

Display in print modal as well, replacing the template expression `{{ statBlock.wildCard ? '(WC)' : '' }}`

Expanded statBlock with the glyph index number as this will allow it to be wrapped up into the export when that feature is implemented.
