### PR TITLE
Unit data local save and limited export

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,11 +54,12 @@
                 <li><a href=#" data-toggle="modal" data-target="#aboutModal">About</a></li>
                 <li><a href=#" data-toggle="modal" data-target="#printModal">Print</a></li>
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" ng-click="generateExport()">Unit<span class="caret"></span></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" ng-click="generateExport(); unitListing = listPersistent();">Unit<span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a ng-href="{{exportUri}}" target="_blank" ng-attr-download="{{ statBlock.datakeyName()+'.json' }}">Export to JSON</a></li>
                         <li role="separator" class="divider"></li>
                         <li><a href="#" ng-click="persist()" title="in browser localStorage">Save</a></li>
+                        <li><a href="#" data-toggle="modal" data-target="#loadunitModal"  title="from browser localStorage">Load...</a></li>
                     </ul>
                  </li>
             </ul>
@@ -329,6 +330,28 @@
             Built-in Bootstrap Glyphicons courtesy of <a href="http://glyphicons.com/">Glyphicons</a>.
         </div>
         <div class="col-md-1"></div>
+    </div>
+</div>
+
+
+<!-- Load Unit Modal -->
+<div class="modal fade" id="loadunitModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>Load locally saved units</h4>
+            </div>
+            <div class="modal-body">
+                <ul>
+				    <li ng-repeat="retrievedUnit in unitListing"><a href="#" ng-click="loadUnit(retrievedUnit.datakeyName)">{{retrievedUnit.name}}</a></li>
+                </ul>
+            <div class="modal-footer">
+                <div class="pull-right hidden-print">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+
+        </div>
     </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,14 @@
                 <li class="active"><a href="#">Home</a></li>
                 <li><a href=#" data-toggle="modal" data-target="#aboutModal">About</a></li>
                 <li><a href=#" data-toggle="modal" data-target="#printModal">Print</a></li>
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" ng-click="generateExport()">Unit<span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                        <li><a ng-href="{{exportUri}}" target="_blank" ng-attr-download="{{ statBlock.datakeyName()+'.json' }}">Export to JSON</a></li>
+                        <li role="separator" class="divider"></li>
+                        <li><a href="#" ng-click="persist()" title="in browser localStorage">Save</a></li>
+                    </ul>
+                 </li>
             </ul>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -335,6 +335,7 @@
 </div>
 
 
+
 <!-- Load Unit Modal -->
 <div class="modal fade" id="loadunitModal" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-lg">
@@ -351,7 +352,7 @@
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </div>
             </div>
-
+          </div>
         </div>
     </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <script src="js/shared/bootstrap.min.js"></script>
     <!--<script src= "http://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>-->
     <script src="js/shared/angular.min.js"></script>
+    <script src="js/shared/polyfill.js"></script>
 
     <script src="js/app.js"/></script>
     <script src="js/controllers/mainController.js"/></script>

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,6 @@ var app = angular.module('showdownTroopBuilder', []); // Empty array is dependan
 app.config(['$logProvider','$compileProvider', function($logProvider,$compileProvider) { 
   $logProvider.debugEnabled(true);
 
-  //To prefent "unsafe" prefix on the generate JSON export link
+  //To prevent angular from inserting "unsafe" prefix on the generate JSON export link
   $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|data):/);
 }]);

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,8 @@
 var app = angular.module('showdownTroopBuilder', []); // Empty array is dependant modules
 
-app.config(function($logProvider) {
+app.config(['$logProvider','$compileProvider', function($logProvider,$compileProvider) { 
   $logProvider.debugEnabled(true);
-});
+
+  //To prefent "unsafe" prefix on the generate JSON export link
+  $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|data):/);
+}]);

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -164,6 +164,7 @@ app.controller('mainController', function($scope) {
     ];
 
     $scope.exportUri = '';
+    $scope.unitListing = [];
 
     // Reference Data
     $scope.edges = EDGES;
@@ -187,6 +188,23 @@ app.controller('mainController', function($scope) {
 
     $scope.persist = function () {
 		localStorage[$scope.statBlock.datakeyName()] = angular.toJson($scope.statBlock);
+	};
+
+    $scope.listPersistent = function () {
+        //Warning: do not make this a source of an ng-repeat directly. Since it is "dynamic", Angular will helpfully rerere(etc)-evaluate
+        var unitList = [];
+        for (var i = 0; i < localStorage.length; i++) {
+			if (localStorage.key(i).match(/^ShowdownTroopBuilder\.Unit\./i)) {
+				var unitStatBlock = angular.fromJson(localStorage.getItem(localStorage.key(i)));
+				unitList.push({name:unitStatBlock.name,datakeyName:localStorage.key(i)});
+			}
+        }
+        return unitList;
+	};
+
+    $scope.loadUnit = function (datakeyName) {
+		var unitStatBlock = angular.fromJson(localStorage.getItem(datakeyName));
+		unitStatBlock && Object.assign($scope.statBlock, unitStatBlock); 
 	};
 
     $scope.generateExport = function () {

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -151,6 +151,8 @@ app.controller('mainController', function($scope) {
 
 
         datakeyName: function() {
+            //This defines the keynames as they appear in localStorage, so you only have to change it 
+            //in one place. Note that changing the prefix would make stored characters "disappear".
             //Might be used in multiple places. At least localStorage keys and download filename hints.
             return 'ShowdownTroopBuilder.Unit.' + (this.name ? this.name.replace(/\W/g,'') : 'Unnamed');
         }
@@ -191,7 +193,7 @@ app.controller('mainController', function($scope) {
 	};
 
     $scope.listPersistent = function () {
-        //Warning: do not make this a source of an ng-repeat directly. Since it is "dynamic", Angular will helpfully rerere(etc)-evaluate
+        //Warning: do not make this a source of an ng-repeat binding directly. Since it is "dynamic", Angular will helpfully rerere(etc)-evaluate
         var unitList = [];
         for (var i = 0; i < localStorage.length; i++) {
 			if (localStorage.key(i).match(/^ShowdownTroopBuilder\.Unit\./i)) {

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -147,6 +147,12 @@ app.controller('mainController', function($scope) {
         getObjectFromJsonString: function(itemString) {
             var item = angular.fromJson(itemString);
             return item;
+        },
+
+
+        datakeyName: function() {
+            //Might be used in multiple places. At least localStorage keys and download filename hints.
+            return 'ShowdownTroopBuilder.Unit.' + (this.name ? this.name.replace(/\W/g,'') : 'Unnamed');
         }
 
     };
@@ -156,6 +162,8 @@ app.controller('mainController', function($scope) {
 		/* Apparently not available in currently utilzed version of Boostrap:
 		 ,'conifer','cd','alert','king','queen','pawn','bishop','knight','apple','hourglass','grain','triangle-top' */
     ];
+
+    $scope.exportUri = '';
 
     // Reference Data
     $scope.edges = EDGES;
@@ -176,5 +184,13 @@ app.controller('mainController', function($scope) {
       //Just cycle to the next icon. The icons are the "built-in" Bootstrap icons, selected for proper flavor.
         this.statBlock.wildCardIconIndex = (this.statBlock.wildCardIconIndex + 1) % this.wcGlyphiconSet.length;
     };
+
+    $scope.persist = function () {
+		localStorage[$scope.statBlock.datakeyName()] = angular.toJson($scope.statBlock);
+	};
+
+    $scope.generateExport = function () {
+		$scope.exportUri = 'data:application/json,' +  angular.toJson($scope.statBlock);
+	};
 
 });

--- a/js/shared/polyfill.js
+++ b/js/shared/polyfill.js
@@ -1,4 +1,5 @@
-//IE lacks support for this function. 
+//Object.assign(targetObject)
+//IE lacks support for this apparently standard method
 //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility
 if (typeof Object.assign != 'function') {
   (function () {

--- a/js/shared/polyfill.js
+++ b/js/shared/polyfill.js
@@ -1,0 +1,26 @@
+//IE lacks support for this function. 
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility
+if (typeof Object.assign != 'function') {
+  (function () {
+    Object.assign = function (target) {
+      'use strict';
+      // We must check against these specific cases.
+      if (target === undefined || target === null) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var output = Object(target);
+      for (var index = 1; index < arguments.length; index++) {
+        var source = arguments[index];
+        if (source !== undefined && source !== null) {
+          for (var nextKey in source) {
+            if (source.hasOwnProperty(nextKey)) {
+              output[nextKey] = source[nextKey];
+            }
+          }
+        }
+      }
+      return output;
+    };
+  })();
+}


### PR DESCRIPTION
Add a new menu where options for saving and recalling from localStorage are available. Storage key is based on Unit name input, value is just a JSON serialization of the controller's statBlock (excellent decision on isolating all that into an object, made this really easy).

Using some of the controller methods form localStorage, introduce limited JSON export (but not import, yet). JSON export works well on Chrome, but seems to cause navigation instead of download in IE. I intend to file an issue for that and work on it later.

Had much better luck with rebase this time. Instead of trying to do a pull at the end, did a force update on the topic branch. Previously I had fear of "force", but I think it is the right thing to do, as long as it is A) only a topic branch and B) you are the only one modifying it, although it is permissible to have a remote/non-local edition to keep in sync with (http://stackoverflow.com/questions/15143042/cant-push-to-branch-after-rebase).
