### PR TITLE
Support Deletion of saved units, improved import and export

### DIFF
--- a/css/showdownTroopBuilder.css
+++ b/css/showdownTroopBuilder.css
@@ -1,3 +1,25 @@
+#fileImportUnit label {
+/* Emulate .dropdown-menu>li>a { 
+   This is based on a particular template in an element directive,
+   so if that changes, this must change accordingly.
+   //TODO: probably should convert to using new special classes instead of ID.
+*/
+    cursor: pointer;
+    display: block;
+    padding: 3px 20px;
+    padding-top: 3px;
+    padding-right: 20px;
+    padding-bottom: 3px;
+    padding-left: 20px;
+    clear: both;
+    font-weight: 400;
+    line-height: 1.42857143;
+    color: #333;
+    white-space: nowrap;
+}
+#fileImportUnit > input {
+	display:none;
+}
 
 #wc-glyphicon {
 	margin-left: 1.25em;

--- a/css/showdownTroopBuilder.css
+++ b/css/showdownTroopBuilder.css
@@ -4,6 +4,16 @@
 	margin-top: .25em;
 }
 
+#loadunitModal .modal-dialog {
+	max-width: 30em;
+}
+
+#loadunitModal .deleteMinibutton {
+    right: 2em;
+	float: right;
+	margin-left: 2em;
+}
+
 @media (min-width: 480px) {
 	#wc-glyphicon {
 		display: block;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <script src="js/app.js"/></script>
     <script src="js/controllers/mainController.js"/></script>
     <script src="js/directives/diePicker.js"/></script>
+    <script src="js/directives/filePicker.js"/></script>
     <script src="js/edges.js"></script>
     <script src="js/specialAbilities.js"></script>
     <script src="js/armor.js"></script>
@@ -58,6 +59,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" ng-click="generateExport(); unitListing = listPersistent();">Unit<span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a ng-href="{{exportUri}}" target="_blank" ng-attr-download="{{ statBlock.datakeyName()+'.json' }}">Export to JSON</a></li>
+                        <li><file-picker id="fileImportUnit" label-text="Import from JSON" on-change-handler="importUnit" extension-filter=".json"></file-picker></li>
                         <li role="separator" class="divider"></li>
                         <li><a href="#" ng-click="persist()" title="in browser localStorage">Save</a></li>
                         <li><a href="#" data-toggle="modal" data-target="#loadunitModal"  title="from browser localStorage">Load...</a></li>

--- a/index.html
+++ b/index.html
@@ -574,7 +574,7 @@
                 <h4>Known Issues</h4>
                 <p>
                     <ul>
-                        <li>Print generates an extra blank page with the logo at the bottom</li>
+                        <li>Cannot unselect a Skill once selected</li>
                     </ul>
                 </p>
             </div>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,9 @@
             </div>
             <div class="modal-body">
                 <ul>
-				    <li ng-repeat="retrievedUnit in unitListing"><a href="#" ng-click="loadUnit(retrievedUnit.datakeyName)">{{retrievedUnit.name}}</a></li>
+				    <li ng-repeat="retrievedUnit in unitListing"><a href="#" ng-click="loadUnit(retrievedUnit.datakeyName)">{{retrievedUnit.name}}</a>
+                        <span class="deleteMinibutton badge glyphicon glyphicon-remove" aria-hidden="true" ng-click="deleteUnit(retrievedUnit.datakeyName)" > </span>
+				    </li>
                 </ul>
             <div class="modal-footer">
                 <div class="pull-right hidden-print">

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -182,6 +182,9 @@ app.controller('mainController', function($scope) {
       };
     };
 
+    //Apparently even a shallow watch on arrays is not the default. Nothing additional to do (hence the empty function body).
+    //We just want Angular to watch it so that we get the dynamic binding reacting automagically for unitListing & modal too.
+    $scope.$watchCollection('unitListing',function(newList,oldList){   }); 
       
     $scope.wildcardIconCycle = function() {
       //Just cycle to the next icon. The icons are the "built-in" Bootstrap icons, selected for proper flavor.
@@ -205,8 +208,17 @@ app.controller('mainController', function($scope) {
 	};
 
     $scope.loadUnit = function (datakeyName) {
-		var unitStatBlock = angular.fromJson(localStorage.getItem(datakeyName));
-		unitStatBlock && Object.assign($scope.statBlock, unitStatBlock); 
+        var unitStatBlock = angular.fromJson(localStorage.getItem(datakeyName));
+        unitStatBlock && Object.assign($scope.statBlock, unitStatBlock); 
+	};
+
+    $scope.deleteUnit = function (datakeyName) {
+        localStorage.removeItem(datakeyName);
+		for(var i = 0; i < $scope.unitListing.length; i++) {
+            if ($scope.unitListing[i].datakeyName == datakeyName) {
+               $scope.unitListing.splice(i,1);
+            }
+        }
 	};
 
     $scope.generateExport = function () {

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -222,17 +222,17 @@ app.controller('mainController', function($scope) {
 	};
 
     $scope.generateExport = function () {
-		$scope.exportUri = 'data:application/json,' +  angular.toJson($scope.statBlock);
+		$scope.exportUri = 'data:application/json,' +  angular.toJson($scope.statBlock).replace(/ /g,'%20');
 	};
 
     $scope.importUnit = function (pickerEvent) {  //Meant to be bound to a file input control change event.
-        console.log(pickerEvent.target.files[0]);
         var fImportFile = new FileReader();
         if (!fImportFile) {
             console.log("Sorry, cannot detect the needed FileReader object. Disabling import options.");
             ///TODO: disable the menu entry.
         } else {
             ///TODO: filetype checks
+            console.log('Loading file ' + pickerEvent.target.files[0].name);
             fImportFile.onload = function(evt){
                 ///TODO: sanity check (regex, length)
                 var unitStatBlock = angular.fromJson(evt.target.result);

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -228,11 +228,11 @@ app.controller('mainController', function($scope) {
     $scope.importUnit = function (pickerEvent) {  //Meant to be bound to a file input control change event.
         var fImportFile = new FileReader();
         if (!fImportFile) {
-            console.log("Sorry, cannot detect the needed FileReader object. Disabling import options.");
+            log("Sorry, cannot detect the needed FileReader object. Disabling import options.");
             ///TODO: disable the menu entry.
         } else {
             ///TODO: filetype checks
-            console.log('Loading file ' + pickerEvent.target.files[0].name);
+            log('Loading file ' + pickerEvent.target.files[0].name);
             fImportFile.onload = function(evt){
                 ///TODO: sanity check (regex, length)
                 var unitStatBlock = angular.fromJson(evt.target.result);

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -187,7 +187,7 @@ app.controller('mainController', function($scope) {
     $scope.$watchCollection('unitListing',function(newList,oldList){   }); 
       
     $scope.wildcardIconCycle = function() {
-      //Just cycle to the next icon. The icons are the "built-in" Bootstrap icons, selected for proper flavor.
+        //Just cycle to the next icon. The icons are the "built-in" Bootstrap icons, selected for proper flavor.
         this.statBlock.wildCardIconIndex = (this.statBlock.wildCardIconIndex + 1) % this.wcGlyphiconSet.length;
     };
 
@@ -224,5 +224,25 @@ app.controller('mainController', function($scope) {
     $scope.generateExport = function () {
 		$scope.exportUri = 'data:application/json,' +  angular.toJson($scope.statBlock);
 	};
+
+    $scope.importUnit = function (pickerEvent) {  //Meant to be bound to a file input control change event.
+        console.log(pickerEvent.target.files[0]);
+        var fImportFile = new FileReader();
+        if (!fImportFile) {
+            console.log("Sorry, cannot detect the needed FileReader object. Disabling import options.");
+            ///TODO: disable the menu entry.
+        } else {
+            ///TODO: filetype checks
+            fImportFile.onload = function(evt){
+                ///TODO: sanity check (regex, length)
+                var unitStatBlock = angular.fromJson(evt.target.result);
+                ///TODO: more sanity checks on the instantiated object?
+                unitStatBlock && Object.assign($scope.statBlock, unitStatBlock); 
+                //Since FileAPI is sufficiently nonstandard, and thus not very included in Angular core, we have some manual duties here.
+                $scope.$apply();  //Just to get view to refresh after "non-standard" activity.
+            };
+            fImportFile.readAsText(pickerEvent.target.files[0]);
+        }
+    };
 
 });

--- a/js/directives/filePicker.js
+++ b/js/directives/filePicker.js
@@ -1,0 +1,24 @@
+//Supporting AngularJS components for the TroopBuilder Single-Page-Application
+
+app.directive('filePicker', function() {
+  //client-side only consumption of local files. Particularly Unit export files.
+  //Solution adapted from one provided by sqren via http://stackoverflow.com/a/19647381/537243
+  //IE9 does not support FormData so you cannot really get the file object from the change event.
+  //Also, the label's automatically click-listening is from https://developer.mozilla.org/en-US/docs/Using_files_from_web_applications
+  return {
+    restrict: 'E',
+    template: '<span> <input type="file" id="{{id}}picker" accept="{{extensionFilter}}" style="display:none;"/> <label for="{{id}}picker">{{labelText}}</label> </span>', //invisi-display the input and proxy-push the button via events? or CSS style the button to seem like a menu entry?
+    replace: true,
+    scope: {
+        labelText: '@labelText',
+        extensionFilter: '@extensionFilter',
+        onChangeHandler: '@onChangeHandler',
+        id: '@id'
+    },
+    link: function (scope,element,attrs) {
+      var onChangeHandler = scope.$parent.$eval(attrs.onChangeHandler);
+      element.find("input").bind('change', onChangeHandler);
+    }
+  };
+});
+

--- a/js/shared/polyfill.js
+++ b/js/shared/polyfill.js
@@ -25,3 +25,16 @@ if (typeof Object.assign != 'function') {
     };
   })();
 }
+
+
+// Not a polyfill, but a wrapper, really.
+// usage: log('inside coolFunc',this,arguments);
+// http://paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
+window.log = function(){
+  log.history = log.history || [];   // store logs to an array for reference
+  log.history.push(arguments);
+  if(this.console){
+    console.log( Array.prototype.slice.call(arguments) );
+  }
+};
+  


### PR DESCRIPTION
Expanding the Unit menu with import option, and giving the localStorage-based Load modal dialog buttons to delete units. A few other fixes and improvements. 

I'm struggling with IE's export support. It definitely does not work correctly right now. I'd like to move forward with that as a known problem.

Requesting a little sanity/regression testing on this one, particularly on platforms other than Windows and Android; after a round of testing of Chrome-on-Windows and Android browser, it looks ok to me.